### PR TITLE
Lattice Ice40 updates

### DIFF
--- a/HDL/IKAOPM.v
+++ b/HDL/IKAOPM.v
@@ -1,4 +1,5 @@
-module IKAOPM #(parameter FULLY_SYNCHRONOUS = 1, parameter FAST_RESET = 0) (
+module IKAOPM #(parameter FULLY_SYNCHRONOUS = 1, parameter FAST_RESET = 0,
+                parameter USE_BRAM = 0) (
     //chip clock
     input   wire            i_EMUCLK, //emulator master clock
 
@@ -205,7 +206,7 @@ IKAOPM_timinggen #(
 
 
 IKAOPM_reg #(
-    .USE_BRAM_FOR_D32REG        (0                          ),
+    .USE_BRAM_FOR_D32REG        (USE_BRAM                   ),
     .FULLY_SYNCHRONOUS          (FULLY_SYNCHRONOUS          )
 ) REG (
     .i_EMUCLK                   (i_EMUCLK                   ),
@@ -338,7 +339,7 @@ IKAOPM_lfo LFO (
 
 
 IKAOPM_pg #(
-    .USE_BRAM_FOR_PHASEREG      (0                          )
+    .USE_BRAM_FOR_PHASEREG      (USE_BRAM                   )
 ) PG (
     .i_EMUCLK                   (i_EMUCLK                   ),
 

--- a/HDL/IKAOPM_modules/IKAOPM_reg.v
+++ b/HDL/IKAOPM_modules/IKAOPM_reg.v
@@ -777,7 +777,7 @@ end
 wire        [7:0]   internal_data = o_TEST[7] ? {i_REG_PHASE_CH6_C2, i_REG_ATTENLEVEL_CH8_C2, i_REG_OPDATA[13:8]} : i_REG_OPDATA[7:0];
 assign  o_D = o_TEST[6] ? internal_data : {write_busy, 5'b00000, i_TIMERB_FLAG, i_TIMERA_FLAG};
 
-assign  o_D_OE = ~|{~mrst_n, i_A0, i_RD_n, i_CS_n};
+assign  o_D_OE = ~|{~mrst_n, i_RD_n, i_CS_n};
 
 
 endmodule

--- a/HDL/IKAOPM_modules/IKAOPM_reg.v
+++ b/HDL/IKAOPM_modules/IKAOPM_reg.v
@@ -732,13 +732,15 @@ else begin: d32reg_mode_bram
     (.i_EMUCLK(i_EMUCLK), .i_CEN_n(phi1ncen_n), .i_CNTRRST(d32reg_cntr_rst), .i_WR(rege0_ff_en), .i_D(d1l_in), .o_Q_TAP(o_D1L));
 
     primitive_sr_bram #(.WIDTH(1), .LENGTH(32), .TAP(32)) u_amen_reg 
-    (.i_EMUCLK(i_EMUCLK), .i_CEN_n(phi1ncen_n), .i_CNTRRST(d32reg_cntr_rst), .i_WR(rega0_bf_en), .i_D(amen_in), .o_Q_TAP());
+    (.i_EMUCLK(i_EMUCLK), .i_CEN_n(phi1ncen_n), .i_CNTRRST(d32reg_cntr_rst), .i_WR(rega0_bf_en), .i_D(amen_in), .o_Q_TAP(amen_out));
 
     primitive_sr_bram #(.WIDTH(2), .LENGTH(32), .TAP(32)) u_ks_reg 
     (.i_EMUCLK(i_EMUCLK), .i_CEN_n(phi1ncen_n), .i_CNTRRST(d32reg_cntr_rst), .i_WR(reg80_9f_en), .i_D(ks_in), .o_Q_TAP(o_KS));
 
     primitive_sr_bram #(.WIDTH(7), .LENGTH(32), .TAP(32)) u_tl_reg 
     (.i_EMUCLK(i_EMUCLK), .i_CEN_n(phi1ncen_n), .i_CNTRRST(d32reg_cntr_rst), .i_WR(reg60_7f_en), .i_D(tl_in), .o_Q_TAP(o_TL));
+
+    assign  o_AMS = ams_out & {2{amen_out}};
 end
 endgenerate
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The steps below show how to instantiate the IKAOPM module in Verilog:
 //Verilog module instantiation example
 IKAOPM #(
     .FULLY_SYNCHRONOUS          (1                          ),
-    .FAST_RESET                 (0                          )
+    .FAST_RESET                 (0                          ),
+    .USE_BRAM                   (0                          )
 ) u_ikaopm_0 (
     .i_EMUCLK                   (                           ),
 
@@ -68,6 +69,7 @@ IKAOPM #(
 
 * `FULLY_SYNCHRONOUS` **1** makes the entire module synchronized(default, recommended). A 2-stage synchronizer is added to all asynchronous control signal inputs. Hence, `i_EMUCLK` at 3.58 MHz, all write operations are delayed by 2 clocks. If **0**, 10 latches are used. There are two unsafe D-latches to emulate an SR-latch for a write request, and an 8-bit D-latch to temporarily store a data bus write value. When using the latches, you must ensure that the enable signals are given the appropriate clock or global attribute. Quartus displays several warnings and treats these signals as GCLK. Because the latch enable signals are considered clocks, the timing analyzer will complain that additional constraints should be added to the bus control signals. I have verified that these asynchronous circuits work on an actual chip, but timing issues may exist.
 * `FAST_RESET` When set to **0**, assertion of the `i_IC_n` for at least 64 cycles of phiM **should be guaranteed during the operation of `i_EMUCLK` and `i_phiM_PCEN_n`** to ensure reset of all pipelines in the IKAOPM. If it is **1**, then if `i_IC_n` is logic low, it forces phi1_cen, the internal divided clock enable, to be enabled so that the pipelines reset at the same rate as the `i_EMUCLK`. Therefore, `i_phiM_PCEN_n` does not need to operate at this time. 
+* `USE_BRAM` When set to **1**, shift registers are implemented by block RAMs, reducing the usage of general logic cells (LUT + flip-flop). Default is **0** - use the general logic to implement shift registers.
 * `i_EMUCLK` is your system clock.
 * `i_phiM_PCEN_n` is the clock enable(negative logic) for positive edge of the phiM.
 * `i_IC_n` is the synchronous reset. To flush every pipelines in the module, IC_n must be kept at zero for at least 64 phiM cycles. Note that while the `i_IC_n` is asserted, the `i_phiM_PCEN_n` must be operating.
@@ -90,3 +92,4 @@ Pin number 8 and 9 of the YM2151 are used as GPO ports. They are referred to as 
 * Altera EP4CE6E22C8: 2231 LEs, 1330 registers, BRAM 6608 bits, fmax=73.83MHz(slow 85C)
 * Altera 5CSEBA6U23I7(MiSTer): 851 ALMs, 1490 registers, BRAM 2952 bits, 1 DSP block, fmax=143.64MHz(slow 100C)
 * Xilinx XC7Z020CLG400(Zynq7020): 1174 LUTs, 116 LUTRAMs, 1579 registers, BRAM 2.5 blocks(8192 bits)
+* Lattice ICE40UP5K-SG48: with USE_BRAM=1: 4516 LC (85%), 10 RAM blocks.


### PR DESCRIPTION
Lattice ICE40 is a simple and small FPGA architecture. It is notable that there exists a fully open-source toolchain for ICE40 (yosis, arachne-pnr, icestorm) making it particularly interesting for DYI and open-source projects.
One downside of the ICE40 is that it does not efficiently implement shift registers: every stage of a shift register is implemented by one complete logic cell (LC). Since YM2151 is particularly heavy on shift registers, it is necessary to enable the USE_BRAM feature in IKAOPM to trade LC usage with BRAMs. Otherwise it does not fit even in 5K device. Therefore, new top-level parameter USE_BRAM is added, which is forwarded to IKAOPM_reg and IKAOPM_pg. 
There was a bug in IKAOPM_reg: when USE_BRAM is enabled, the signal o_AMS was not driven. This is corrected as best as I could.
Finally, there was a bug in generating the bus output-enable signal o_D_OE: based on datasheet, it must NOT depend on the address signal A0, see Fig 3 - Address Map Read mode.
The changes were tested in Lattice ICE40UP5K FPGA, implemented in my Commander-X16 computer clone [https://github.com/jsyk/x65] called X65. The original C'X16 has YM2151 for FM-synth. In my X65 clone it is replaced by IKAOPM in the Lattice FPGA ICE40UP5K, called "AURA"; see fpga-aura in my repository.

Jaroslav.